### PR TITLE
Add node to arrayBuilder.init() call

### DIFF
--- a/src/com/cognitect/transit/impl/decoder.js
+++ b/src/com/cognitect/transit/impl/decoder.js
@@ -274,7 +274,7 @@ decoder.Decoder.prototype.decodeArray = function(node, cache, asMapKey, tagValue
                 }
                 return this.arrayBuilder.fromArray(arr, node);
             } else {
-                var ret = this.arrayBuilder.init();
+                var ret = this.arrayBuilder.init(node);
                 for(var i = 0; i < node.length; i++) {
                     ret = this.arrayBuilder.add(ret, this.decode(node[i], cache, asMapKey, false), node);
                 }


### PR DESCRIPTION
Hi I have a custom handler that will require the node in the init.

It seems to be part of the interface in transit-cljs so I'm not sure why it would be missing from the call