### PR TITLE
Update license field to be SPDX compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
      "polyfill"
   ],
   "author": "Cognitect",
-  "license": "APL",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/cognitect/transit-js.git"


### PR DESCRIPTION
- APL seems to be for Adaptive Public License and not Apache 2.0 (as the https://github.com/cognitect/transit-js/blob/master/LICENSE file says).
- See https://spdx.org/licenses/