### PR TITLE
Update License: "Apache-2.0" is Apache

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
      "polyfill"
   ],
   "author": "Cognitect",
-  "license": "APL",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/cognitect/transit-js.git"


### PR DESCRIPTION
When I audited my dependencies, I found that you seemed to be using [Adaptive Public License](https://opensource.org/licenses/APL-1.0) ("APL").
Since your `LICENSE` file contains Apache 2.0 though, I believe this is a mistake in `package.json`.